### PR TITLE
fix: handle daily discord fetch messages in SQS consumer

### DIFF
--- a/src/services/discord-message-consumer/discord-message-consumer.service.ts
+++ b/src/services/discord-message-consumer/discord-message-consumer.service.ts
@@ -41,7 +41,7 @@ export class DiscordMessageConsumerService {
               console.log(`[${message.messageId}][${JSON.stringify(parsedMessage)}]`, LOG_CTX);
               console.log({ parsedMessage });
 
-              if (parsedMessage.reason === 'user-discord-link') {
+              if (parsedMessage.reason === 'user-discord-link' || parsedMessage.reason === 'discord-fetch-daily') {
                 if (parsedMessage.daos) {
                   await this.getPastMessagesService.getMessages(client, parsedMessage);
                 } else {


### PR DESCRIPTION
## Summary
- The SQS consumer was only processing `user-discord-link` messages, silently dropping `discord-fetch-daily` messages
- This meant `yarn job discord:fetch:messages` was sending SQS messages that were never consumed — Discord messages were only synced when a user first linked their wallet, not on a recurring basis
- Added `discord-fetch-daily` to the consumer's reason check so daily batch fetches are actually processed

## Test plan
- [ ] Deploy the discord-bot consumer
- [ ] Run `yarn job discord:fetch:messages` and verify messages are consumed and inserted into `DelegateDiscordMessage`
- [ ] Verify `user-discord-link` flow still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord message processing logic to correctly handle message retrieval operations in the message consumer service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->